### PR TITLE
Push multi architecture image

### DIFF
--- a/.github/workflows/dockerhub-build-push.yml
+++ b/.github/workflows/dockerhub-build-push.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -35,3 +38,4 @@ jobs:
           context: ./
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.package-info.outputs.IMAGE_NAME }}:${{ steps.package-info.outputs.VERSION }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Updating dockerhub push workflow to add arm64 along with amd64 arch type.

This updated workflow was ran locally via ‘act’ and pushed the image as below.

<img width="611" alt="image" src="https://github.com/dreamup-ai/pipeline-service/assets/38874507/a499fa2c-4274-4928-9d45-37871f3b045e">

Tested pulling images in an arm computer before and after images were pushed thorough this, and it worked.

<img width="657" alt="image" src="https://github.com/dreamup-ai/pipeline-service/assets/38874507/831599f4-8fb0-4ec1-a79b-686f4ab1eae5">

